### PR TITLE
Corrected syntax

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -1242,9 +1242,10 @@ The :py:meth:`~PIL.Image.Image.save` method can take the following keyword argum
     .. versionadded:: 3.0.0
 
 **append_images**
-    A list of :py:class:`PIL.Image.Image`s to append as additional pages. Each of the
-    images in the list can be single or multiframe images. The ``save_all``
-    parameter must be present and set to ``True`` in conjunction with ``append_images``.
+    A list of :py:class:`PIL.Image.Image` objects to append as additional pages. Each
+    of the images in the list can be single or multiframe images. The ``save_all``
+    parameter must be present and set to ``True`` in conjunction with
+    ``append_images``.
 
     .. versionadded:: 4.2.0
 


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/5399

If you look at https://pillow--5399.org.readthedocs.build/en/5399/handbook/image-file-formats.html#pdf, you will see that the documentation change is not rendering correctly.

See https://pillow-radarhere.readthedocs.io/en/docs-pdf-param-update/handbook/image-file-formats.html#pdf for how this PR renders instead.